### PR TITLE
chore(release): promote develop to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,27 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    env:
+      # Use repo-local cache directories to avoid colliding with runner state
+      GOMODCACHE: ${{ github.workspace }}/.cache/go/pkg/mod
+      GOCACHE:    ${{ github.workspace }}/.cache/go-build
+      GO_VERSION: '1.25'
     steps:
       - uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: ${{ env.GO_VERSION }}
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            .cache/go-build
+            .cache/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ env.GO_VERSION }}-
+            ${{ runner.os }}-go-
       - name: Install test deps
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+jobs:
+  snapshot:
+    name: Snapshot (test goreleaser)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/heads/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.25'
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |-
+            ~/.cache/go-build
+            ~/.cache/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Install goreleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: --snapshot --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release (tag)
+    runs-on: ubuntu-latest
+    needs: snapshot
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.25'
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |-
+            ~/.cache/go-build
+            ~/.cache/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Install goreleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,47 @@
+project_name: experia-v10-exporter
+
+builds:
+  - main: ./cmd/experia-v10-exporter
+    binary: experia-v10-exporter
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+
+archives:
+  - builds:
+      - experia-v10-exporter
+    format: tar.gz
+    files:
+      - README.md
+      - LICENSE
+
+changelog:
+  use: git
+
+snapshot:
+  name_template: "{{ .Tag }}-SNAPSHOT"
+
+dockers:
+  - image_templates:
+      - "ghcr.io/{{ .ProjectOwner }}/{{ .ProjectName }}:{{ .Tag }}"
+    use: buildx
+    platforms:
+      - linux/amd64
+      - linux/arm64
+
+release:
+  github:
+    owner: GrammaTonic
+    name: experia-v10-exporter
+
+archive:
+  format_overrides:
+    - goos: windows
+      format: zip

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,73 @@
+# Release Guide for experia-v10-exporter
+
+This document explains the steps and required repository secrets to perform a release using Goreleaser and GitHub Actions.
+
+## Required repository secrets
+
+- `GHCR_TOKEN` (recommended): a personal access token (PAT) that has the appropriate package permissions to push container images to GitHub Container Registry (GHCR). Scopes: `write:packages` and `read:packages` (or `packages:write` depending on GitHub's permission names). If you prefer to use `GITHUB_TOKEN` for release creation only, goreleaser can still create GitHub releases with the default `GITHUB_TOKEN` but pushing to GHCR may require a PAT.
+
+- `GITHUB_TOKEN`: automatically provided in Actions; used by goreleaser to create GitHub Releases. No manual setup required.
+
+## Tagging strategy
+
+We follow semver tags. Tag format: `vMAJOR.MINOR.PATCH` (for example `v1.2.3`).
+
+To create a release tag locally and push it:
+
+```bash
+# from the repository root on the branch you want to release (typically main)
+git fetch --prune
+git checkout main
+git pull --ff-only origin main
+# create tag
+git tag -a v1.2.3 -m "Release v1.2.3"
+# push tag
+git push origin v1.2.3
+```
+
+Pushing the tag will trigger the `Release` workflow which runs goreleaser and publishes artifacts and Docker images (if `GHCR_TOKEN` is configured).
+
+## Testing a release locally (snapshot)
+
+You can test goreleaser locally without publishing by running the snapshot command:
+
+```bash
+# install goreleaser (if not already)
+brew install goreleaser/tap/goreleaser || curl -sL https://git.io/goreleaser | bash
+
+# run a snapshot locally
+goreleaser --snapshot --rm-dist
+```
+
+This creates `dist/` artifacts and validates the config without publishing.
+
+## Releasing from CI (GitHub Actions)
+
+The repository contains `.github/workflows/release.yml` which:
+
+- Runs a `snapshot` job for pull requests and pushes to `main` to validate the release process.
+- Runs a `release` job on semver tag pushes that executes `goreleaser release --rm-dist`.
+
+If you want to publish Docker images to GHCR, ensure `GHCR_TOKEN` is set in repository secrets. The workflow logs in to GHCR before running goreleaser.
+
+## Post-release checks
+
+After the release workflow completes, verify:
+
+- A GitHub Release was created with the tag name and the expected changelog.
+- `dist/` artifacts look correct (binaries and archives).
+- Docker images are present in GHCR with the tag (if publishing enabled).
+
+## Troubleshooting
+
+- If goreleaser fails with schema/linter errors, run `goreleaser check` locally to get more detail.
+- If Docker pushes fail due to permission errors, check that `GHCR_TOKEN` has the correct package permissions and belongs to a user with access to the repo or org.
+- For runner caching issues, ensure your workflow cache keys are stable and avoid restoring archives on top of existing files that cause tar extraction conflicts.
+
+## Rollback
+
+If a release must be retracted, delete the GitHub Release and the Git tag, and optionally delete the GHCR package versions. Create a follow-up tag for the correct release.
+
+## Contact
+
+If you're unsure, ping the repository maintainer for guidance before performing production releases.

--- a/docs/HOW_TO_GET_WAN_METRICS.md
+++ b/docs/HOW_TO_GET_WAN_METRICS.md
@@ -37,3 +37,9 @@ the respose is:
 
 the respose is: 
 {"status":{"RxPackets":140045735,"TxPackets":53436844,"RxBytes":7460867824,"TxBytes":8258926237,"RxErrors":0,"TxErrors":0,"RxDropped":0,"TxDropped":0,"Multicast":2238353,"Collisions":0,"RxLengthErrors":0,"RxOverErrors":0,"RxCrcErrors":0,"RxFrameErrors":0,"RxFifoErrors":0,"RxMissedErrors":0,"TxAbortedErrors":0,"TxCarrierErrors":0,"TxFifoErrors":0,"TxHeartbeatErrors":0,"TxWindowErrors":0}}
+
+## Notes about WAN discovery and exporter health
+
+- The exporter includes a deterministic WAN detection and exposes the discovery metric `experia_v10_wan_ifname{ifname="<IFNAME>"}` which indicates the interface the collector considers the WAN.
+- When testing with Docker, the image includes a tiny `/probe` binary used by the `HEALTHCHECK` to wait until `/metrics` is available. If your Docker image lacks `/probe`, the healthcheck will fail with an exec error.
+- To reproduce the MIB calls manually, compare `LLAddress` (MAC) and `Alias` fields from the `get` and `getNetDevStats` calls shown above to determine which interface is the WAN.


### PR DESCRIPTION
Promote changes from develop to main. Includes release workflow, docs, and goreleaser config. CI will run on the merge to build artifacts.